### PR TITLE
Add sign-in function for administrator

### DIFF
--- a/Lottery/app/src/main/java/com/example/lottery/AdminSignInActivity.java
+++ b/Lottery/app/src/main/java/com/example/lottery/AdminSignInActivity.java
@@ -1,16 +1,38 @@
 package com.example.lottery;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
+/**
+ * Admin authentication screen.
+ * <p>
+ * Verifies a secret access code against admin_codes/primary_admin_code in Firestore.
+ * The document must have a "code" (String) and "isActive" (Boolean) field.
+ * On success, navigates to AdminBrowseEventsActivity.
+ */
 public class AdminSignInActivity extends AppCompatActivity {
 
-    private FirebaseFirestore db;
+    private static final String ADMIN_CODES = "admin_codes";
+    private static final String PRIMARY_ADMIN_CODE = "primary_admin_code";
 
+    private FirebaseFirestore db;
+    private EditText adminCodeInput;
+    private Button signInButton;
+
+    /**
+     * Initialize the activity and binds UI views.
+     *
+     * @param savedInstanceState previously saved instance state, or null if not exist.
+     */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -18,7 +40,71 @@ public class AdminSignInActivity extends AppCompatActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_admin_sign_in);
 
-        // Initialize firebase
         db = FirebaseFirestore.getInstance();
+        adminCodeInput = findViewById(R.id.etAdminCode);
+        signInButton = findViewById(R.id.btnSignIn);
+
+        signInButton.setOnClickListener(view -> validateAdminCode());
+    }
+
+    /**
+     * Fetches the admin code from Firestore and validates it against the user's input.
+     * Navigates to AdminBrowseEventsActivity on success.
+     */
+    private void validateAdminCode() {
+        String enteredCode = adminCodeInput.getText().toString().trim();
+
+        // Skip call if input is empty.
+        if (enteredCode.isEmpty()) {
+            adminCodeInput.setError(getString(R.string.error_admin_code_required));
+            return;
+        }
+
+        // Prevent duplicate submissions while the request is under processing.
+        signInButton.setEnabled(false);
+
+        db.collection(ADMIN_CODES).document(PRIMARY_ADMIN_CODE)
+                .get()
+                .addOnCompleteListener(task -> {
+                    signInButton.setEnabled(true);
+
+                    if (!task.isSuccessful()) {
+                        Toast.makeText(this, R.string.error_admin_code_lookup_failed,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    DocumentSnapshot document = task.getResult();
+
+                    // Document missing — admin code has not been configured in Firestore.
+                    if (document == null || !document.exists()) {
+                        Toast.makeText(this, R.string.error_admin_code_not_configured,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    String storedCode = document.getString("code");
+                    Boolean isActive = document.getBoolean("isActive");
+
+                    if (storedCode == null) {
+                        Toast.makeText(this, R.string.error_admin_code_not_configured,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (!Boolean.TRUE.equals(isActive)) {
+                        Toast.makeText(this, R.string.error_admin_code_inactive,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
+
+                    if (!storedCode.equals(enteredCode)) {
+                        adminCodeInput.setError(getString(R.string.error_incorrect_admin_code));
+                        return;
+                    }
+
+                    startActivity(new Intent(this, AdminBrowseEventsActivity.class));
+                    finish();
+                });
     }
 }

--- a/Lottery/app/src/main/res/layout/activity_admin_sign_in.xml
+++ b/Lottery/app/src/main/res/layout/activity_admin_sign_in.xml
@@ -9,39 +9,24 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
         android:text="@string/admin_sign_in_title"
-        android:textSize="24sp"
-        android:layout_marginBottom="24dp"/>
+        android:textSize="24sp" />
 
     <EditText
         android:id="@+id/etAdminCode"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
         android:hint="@string/admin_code"
-        android:inputType="text"
-        android:layout_marginBottom="12dp"/>
-
-<!--    <EditText-->
-<!--        android:id="@+id/etEmail"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:hint="@string/email"-->
-<!--        android:inputType="textEmailAddress"/>-->
-
-<!--    <EditText-->
-<!--        android:id="@+id/etPassword"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:hint="@string/password"-->
-<!--        android:inputType="textPassword"-->
-<!--        android:layout_marginTop="12dp"/>-->
+        android:inputType="textPassword" />
 
     <Button
         android:id="@+id/btnSignIn"
         android:layout_width="match_parent"
         android:layout_height="56dp"
+        android:layout_marginTop="24dp"
         android:text="@string/sign_in"
-        android:textSize="16sp"
-        android:layout_marginTop="24dp"/>
+        android:textSize="16sp" />
 
 </LinearLayout>

--- a/Lottery/app/src/main/res/values/strings.xml
+++ b/Lottery/app/src/main/res/values/strings.xml
@@ -20,6 +20,11 @@
     <string name="error_name_required">Name is required</string>
     <string name="error_password_required">Password is required</string>
     <string name="error_invalid_password">Invalid password</string>
+    <string name="error_admin_code_required">Admin code is required</string>
+    <string name="error_incorrect_admin_code">Admin code is incorrect</string>
+    <string name="error_admin_code_lookup_failed">Failed to verify admin code</string>
+    <string name="error_admin_code_not_configured">Admin code is not configured</string>
+    <string name="error_admin_code_inactive">Admin code is inactive</string>
     <string name="back_button_description">Return to Role Selection</string>
     <string name="sign_in_title">Sign In</string>
     <string name="admin_sign_in_title">Admin Sign In</string>


### PR DESCRIPTION
## Summary

- Add admin sign-in screen that validates a secret code against Firestore
- Block sign-in if code is missing, inactive, or incorrect
- Navigate to AdminBrowseEventsActivity on success

## Code Changes

- Fetch and validate code from admin_codes/primary_admin_code in Firestore which are pre-defined and pre-stored.
- Check isActive flag before accepting the code, if not active, should not be accepted.
- Disable sign-in button during request
- Add error string resources for all validation failure cases

## Files Changed

- AdminSignInActivity.java
- activity_admin_sign_in.xml
- strings.xml