### PR TITLE
Replace toasts with state text on entrant map screen

### DIFF
--- a/Lottery/app/src/main/java/com/example/lottery/EntrantMapActivity.java
+++ b/Lottery/app/src/main/java/com/example/lottery/EntrantMapActivity.java
@@ -2,7 +2,9 @@ package com.example.lottery;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 import android.widget.ImageButton;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
@@ -30,8 +32,8 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 import java.util.ArrayList;
 
 /**
- * Activity to display entrants' locations on a map for a specific event.
- * Shows all entrants regardless of their individual status if requireLocation is true for the event.
+ * Activity to display the locations of all entrants with saved coordinates for a
+ * specific event's waitingList records.
  */
 public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyCallback {
 
@@ -39,6 +41,7 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
     private final ArrayList<EntrantEvent> entrants = new ArrayList<>();
     private GoogleMap googleMap;
     private MapView mapView;
+    private TextView tvMapState;
     private String eventId;
     private FirebaseFirestore db;
 
@@ -57,7 +60,7 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
         eventId = getIntent().getStringExtra("eventId");
 
         if (eventId == null) {
-            Toast.makeText(this, "Event ID missing", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.error_event_id_missing, Toast.LENGTH_SHORT).show();
             finish();
             return;
         }
@@ -68,10 +71,31 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
         }
 
         mapView = findViewById(R.id.mapView);
+        tvMapState = findViewById(R.id.tvMapState);
         mapView.onCreate(savedInstanceState);
         mapView.getMapAsync(this);
+        showMapState(R.string.loading_entrant_locations);
 
         checkRequirementAndFetch();
+    }
+
+    private void showMapState(int messageResId) {
+        if (tvMapState != null) {
+            tvMapState.setText(messageResId);
+            tvMapState.setVisibility(View.VISIBLE);
+        }
+        if (mapView != null) {
+            mapView.setVisibility(View.GONE);
+        }
+    }
+
+    private void showMapContent() {
+        if (tvMapState != null) {
+            tvMapState.setVisibility(View.GONE);
+        }
+        if (mapView != null) {
+            mapView.setVisibility(View.VISIBLE);
+        }
     }
 
     /**
@@ -86,17 +110,20 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
                         if (requireLocation != null && requireLocation) {
                             fetchAllEntrantsLocations();
                         } else {
-                            // If location is not required, the map should technically be empty or not shown.
-                            // Here we show a toast as per user request.
-                            Toast.makeText(this, R.string.location_not_required_for_event, Toast.LENGTH_LONG).show();
+                            showMapState(R.string.location_not_required_for_event);
                         }
+                    } else {
+                        showMapState(R.string.event_not_found);
                     }
                 })
-                .addOnFailureListener(e -> Log.e(TAG, "Error checking event requirement", e));
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error checking event requirement", e);
+                    showMapState(R.string.failed_to_load_entrant_locations);
+                });
     }
 
     /**
-     * Fetches all entrants from the waitingList subcollection who have location data.
+     * Fetches all waitingList entrants for the event who have location data.
      */
     private void fetchAllEntrantsLocations() {
         db.collection(FirestorePaths.eventWaitingList(eventId))
@@ -109,22 +136,22 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
                             entrant.setUserId(snapshot.getId());
                         }
 
-                        // We collect all entrants who have a location, regardless of their status
-                        // (waitlisted, invited, accepted, etc.)
-                        if (entrant.getLocation() != null) {
-                            entrants.add(entrant);
-                        }
+                        if (entrant.getLocation() == null) continue;
+
+                        entrants.add(entrant);
                     }
 
                     if (entrants.isEmpty()) {
-                        Toast.makeText(this, R.string.no_entrant_locations_available, Toast.LENGTH_LONG).show();
-                    }
-
-                    if (googleMap != null) {
+                        showMapState(R.string.no_entrant_locations_available);
+                    } else if (googleMap != null) {
+                        showMapContent();
                         insertMarkers(entrants);
                     }
                 })
-                .addOnFailureListener(e -> Log.e(TAG, "Error fetching entrants", e));
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error fetching entrants", e);
+                    showMapState(R.string.failed_to_load_entrant_locations);
+                });
     }
 
     @Override
@@ -137,6 +164,7 @@ public class EntrantMapActivity extends AppCompatActivity implements OnMapReadyC
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(defaultCenter, 3f));
 
         if (!entrants.isEmpty()) {
+            showMapContent();
             insertMarkers(entrants);
         }
     }

--- a/Lottery/app/src/main/java/com/example/lottery/EntrantsListActivity.java
+++ b/Lottery/app/src/main/java/com/example/lottery/EntrantsListActivity.java
@@ -88,8 +88,6 @@ public class EntrantsListActivity extends AppCompatActivity implements
     private long capacity, maxSampleSize;
     private boolean requireLocation = false;
     private ListenerRegistration entrantsReg;
-    private String activeGroupStatus = InvitationFlowUtil.STATUS_WAITLISTED;
-
     private ActivityResultLauncher<String> createCsvLauncher;
 
     @SuppressLint("NotifyDataSetChanged")
@@ -150,23 +148,18 @@ public class EntrantsListActivity extends AppCompatActivity implements
         showLayout(waitedListEntrantsListLayout);
 
         btnSwitchSignedUp.setOnClickListener(v -> {
-            activeGroupStatus = InvitationFlowUtil.STATUS_ACCEPTED;
             showLayout(signedUpEntrantsListLayout);
         });
         btnSwitchCancelled.setOnClickListener(v -> {
-            activeGroupStatus = InvitationFlowUtil.STATUS_CANCELLED;
             showLayout(cancelledEntrantsListLayout);
         });
         btnSwitchWaitedList.setOnClickListener(v -> {
-            activeGroupStatus = InvitationFlowUtil.STATUS_WAITLISTED;
             showLayout(waitedListEntrantsListLayout);
         });
         btnSwitchInvited.setOnClickListener(v -> {
-            activeGroupStatus = InvitationFlowUtil.STATUS_INVITED;
             showLayout(invitedEntrantsListLayout);
         });
         btnSwitchNotSelected.setOnClickListener(v -> {
-            activeGroupStatus = InvitationFlowUtil.STATUS_NOT_SELECTED;
             showLayout(notSelectedEntrantsListLayout);
         });
 
@@ -176,12 +169,11 @@ public class EntrantsListActivity extends AppCompatActivity implements
         });
 
         /**
-         * navigate to the map screen to view entrant locations (US 02.02.02)
+         * navigate to the map screen to view all saved entrant locations for this event (US 02.02.02)
          */
         btnViewLocation.setOnClickListener(v -> {
             Intent intent = new Intent(this, EntrantMapActivity.class);
             intent.putExtra("eventId", eventId);
-            intent.putExtra("status", activeGroupStatus);
             startActivity(intent);
         });
 

--- a/Lottery/app/src/main/res/layout/activity_entrant_map.xml
+++ b/Lottery/app/src/main/res/layout/activity_entrant_map.xml
@@ -42,11 +42,28 @@
                 android:textStyle="bold" />
         </RelativeLayout>
 
-        <com.google.android.gms.maps.MapView
-            android:id="@+id/mapView"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="16dp"
-            android:layout_weight="1" />
+            android:layout_weight="1">
+
+            <com.google.android.gms.maps.MapView
+                android:id="@+id/mapView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/tvMapState"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:padding="24dp"
+                android:text="@string/loading_entrant_locations"
+                android:textAlignment="center"
+                android:textColor="@color/text_primary"
+                android:textSize="16sp" />
+        </FrameLayout>
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Lottery/app/src/main/res/values/strings.xml
+++ b/Lottery/app/src/main/res/values/strings.xml
@@ -222,8 +222,10 @@
     <string name="delete_profile">Delete Profile</string>
     <string name="delete_profile_message">This action cannot be undone. Your profile data will be deleted and you will be logged out.</string>
     <string name="log_out">Log Out</string>
-    <string name="no_entrant_locations_available">No entrant locations available for this event.</string>
+    <string name="no_entrant_locations_available">No entrant locations available for this status.</string>
     <string name="location_not_required_for_event">Geolocation is not required for this event.</string>
+    <string name="loading_entrant_locations">Loading entrant locations...</string>
+    <string name="failed_to_load_entrant_locations">Failed to load entrant locations.</string>
     <string name="no_entrants_in_list">No entrants in this list</string>
 
     <!-- Confirmation Ticket -->


### PR DESCRIPTION
## Summary

- Show loading, error, and empty states inside the map layout instead of transient Toast messages. The map now displays all entrant locations for the event regardless of tab selection, removing the unused status filter